### PR TITLE
remove neutral check button

### DIFF
--- a/index.html
+++ b/index.html
@@ -964,7 +964,7 @@
   </div>
 </div>
 <button id="clearBlock">clear all</button>
-<button id="checkMatches">check neutrals</button>
+<!-- <button id="checkMatches">check neutrals</button> -->
 <!-- <button id="logBlock">log all</button> -->
 <button id="displayBlock">display all</button>
 <label>Enable color ID<input type="checkbox" id="enableTooltips" ></label>

--- a/print.css
+++ b/print.css
@@ -5,9 +5,9 @@
   .tooltip {
     display: none;
   }
-  /*.quilt {
+  label {
     display: none;
-  }*/
+  }
   #toPrint {
     font-size: 130%;
     list-style: none;


### PR DESCRIPTION
The neutral check happens when the display button is pressed; no need for a special message at this point.